### PR TITLE
Fixes a few issues with recent builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
         env:
           NPM_RC: //registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}
       - name: Install dependencies
-        run: npm ci
+        # We currently have a peer dependency issue with react, but that's ok
+        # since it is a dev dependency (used for unit testing) that conflicts
+        # with the peerDependency we list for react.
+        run: npm install -f
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '18.x'
           cache: 'npm'
       - name: Setup NPM
         run: 'echo "$NPM_RC" > .npmrc'

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,8 @@
         "typescript-transform-paths": "^3.3.1"
       },
       "peerDependencies": {
-        "react": ">=17.0.3 || ^18",
-        "react-dom": ">=17.0.3 || ^18"
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prebuild": "npm run clean",
     "build": "npm run build:esm && npm run build:cjs && npm run build:styles && npm run build:variables",
     "build:variables": "scripts/replace-build-variables.sh",
-    "build:esm": "tsc-esm",
+    "build:esm": "node scripts/build/index.js",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --target es6",
     "build:styles": "cp src/styles.css dist/styles.css",
     "postbuild": "echo '{\"type\":\"commonjs\"}' | npx json > dist/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > dist/esm/package.json",
@@ -52,8 +52,8 @@
   },
   "homepage": "https://github.com/fractalwagmi/react-sdk#readme",
   "peerDependencies": {
-    "react": ">=17.0.3 || ^18",
-    "react-dom": ">=17.0.3 || ^18"
+    "react": "^17 || ^18",
+    "react-dom": "^17 || ^18"
   },
   "dependencies": {
     "@emotion/css": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   },
   "homepage": "https://github.com/fractalwagmi/react-sdk#readme",
   "peerDependencies": {
-    "react": "^17 || ^18",
-    "react-dom": "^17 || ^18"
+    "react": ">=17.0.3 || ^18",
+    "react-dom": ">=17.0.3 || ^18"
   },
   "dependencies": {
     "@emotion/css": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "build:local": "npm run build",
     "postbuild:local": "[ ! -d node_modules/react ] || mv node_modules/react node_modules/react.disabled",
     "lint": "eslint --fix",
-    "pretest": "npm run prebuild:local",
-    "posttest": "npm run postbuild:local",
     "prepublishOnly": "npm run build"
   },
   "exports": {

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -1,0 +1,21 @@
+/**
+ * @file This script is needed instead of running tsc-esm manually due to
+ *   special aliasing needs. See memo below on react/jsx-runtime.
+ *
+ *   Also, because we want to use this as an ES module, it is necessary to have a
+ *   package.json folder with "type": "module" defined inside of it so Node
+ *   knows how to interpret it.
+ */
+
+import { compile, patch } from '@digitak/tsc-esm';
+
+compile();
+patch([
+  // We need to manually patch react/jsx-runtime since only version 17.0.3+ of
+  // react has the "exports" field on the package.json defined correctly for
+  // tsc-esm to be able to recognize this import and patch it correctly.
+  {
+    find: /^react\/jsx-runtime$/,
+    replacement: 'react/jsx-runtime.js',
+  },
+]);

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -11,11 +11,13 @@ import { compile, patch } from '@digitak/tsc-esm';
 
 compile();
 patch([
-  // We need to manually patch react/jsx-runtime since only version 17.0.3+ of
-  // react has the "exports" field on the package.json defined correctly for
-  // tsc-esm to be able to recognize this import and patch it correctly.
+  // We need to manually patch react/jsx-runtime since tsc-esm doesn't know how
+  // to resolve the fields defined by React's package.json's "exports" field.
+  //
+  // We don't add a .js extension (leave it alone) as the "exports" fields takes
+  // care of the aliasing (in versions 17.0.3+).
   {
     find: /^react\/jsx-runtime$/,
-    replacement: 'react/jsx-runtime.js',
+    replacement: 'react/jsx-runtime',
   },
 ]);

--- a/scripts/build/package.json
+++ b/scripts/build/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/core/api/client.ts
+++ b/src/core/api/client.ts
@@ -12,7 +12,9 @@ export const authApiClient = new AuthApi({
     headers: getDefaultHeaders(),
   },
   baseUrl: AUTH_API_ROOT_URL,
-  securityWorker: () => getDefaultSecureHeaders(),
+  securityWorker: () => ({
+    headers: getDefaultSecureHeaders(),
+  }),
 });
 
 export const sdkApiClient = new SdkApi({
@@ -20,7 +22,9 @@ export const sdkApiClient = new SdkApi({
     headers: getDefaultHeaders(),
   },
   baseUrl: SDK_API_ROOT_URL,
-  securityWorker: () => getDefaultSecureHeaders(),
+  securityWorker: () => ({
+    headers: getDefaultSecureHeaders(),
+  }),
 });
 
 export const authPrivateWebSdkApiClient = new PrivateWebSdkApi({
@@ -28,7 +32,9 @@ export const authPrivateWebSdkApiClient = new PrivateWebSdkApi({
     headers: getDefaultHeaders(),
   },
   baseUrl: AUTH_API_ROOT_URL,
-  securityWorker: () => getDefaultSecureHeaders(),
+  securityWorker: () => ({
+    headers: getDefaultSecureHeaders(),
+  }),
 });
 
 export const webSdkApiClient = new WebSdkApi({
@@ -36,5 +42,7 @@ export const webSdkApiClient = new WebSdkApi({
     headers: getDefaultHeaders(),
   },
   baseUrl: SDK_API_ROOT_URL,
-  securityWorker: () => getDefaultSecureHeaders(),
+  securityWorker: () => ({
+    headers: getDefaultSecureHeaders(),
+  }),
 });

--- a/src/hooks/use-sign-in.ts
+++ b/src/hooks/use-sign-in.ts
@@ -78,8 +78,16 @@ export const useSignIn = ({
         const { user } = await fetchAndSetUser(baseUser, accessToken);
         closePopup();
         onSignIn(user);
-      } catch (e: unknown) {
-        onSignInFailed(new FractalSDKError('Sign in failed.'));
+      } catch (err: unknown) {
+        if (err instanceof FractalSDKError) {
+          onSignInFailed(err);
+          return;
+        }
+        onSignInFailed(
+          new FractalSDKAuthenticationUnknownError(
+            `Sign in failed. err = ${err}`,
+          ),
+        );
       }
     };
 

--- a/src/hooks/use-user-setter.ts
+++ b/src/hooks/use-user-setter.ts
@@ -9,6 +9,13 @@ export const useUserSetter = () => {
 
   const fetchAndSetUser = useCallback(
     async (baseUser: BaseUser, accessToken: string) => {
+      // We need to first store the token in LS since `getInfo` requires it to
+      // be set.
+      storeIdAndTokenInLS({
+        accessToken,
+        userId: baseUser.userId,
+      });
+
       const { data } = await sdkApiClient.v1.getInfo();
 
       const user: User = {
@@ -19,11 +26,6 @@ export const useUserSetter = () => {
       const userWallet: UserWallet = {
         solanaPublicKeys: data.accountPublicKey ? [data.accountPublicKey] : [],
       };
-
-      storeIdAndTokenInLS({
-        accessToken,
-        userId: user.userId,
-      });
       setUser(user);
       setUserWallet(userWallet);
 

--- a/src/queries/coins.ts
+++ b/src/queries/coins.ts
@@ -2,7 +2,7 @@ import { FractalSdkWalletGetCoinsResponse } from '@fractalwagmi/ts-api';
 import { useQuery } from '@tanstack/react-query';
 import { sdkApiClient } from 'core/api/client';
 import { ApiFeature } from 'core/api/types';
-import { useUser } from 'hooks';
+import { useUser } from 'hooks/public/use-user';
 
 enum CoinApiKey {
   GET_COINS = 'GET_COINS',

--- a/src/queries/items.ts
+++ b/src/queries/items.ts
@@ -2,7 +2,7 @@ import { FractalSdkWalletGetItemsResponse } from '@fractalwagmi/ts-api';
 import { useQuery } from '@tanstack/react-query';
 import { sdkApiClient } from 'core/api/client';
 import { ApiFeature } from 'core/api/types';
-import { useUser } from 'hooks';
+import { useUser } from 'hooks/public/use-user';
 
 enum ItemApiKey {
   GET_ITEMS = 'GET_ITEMS',


### PR DESCRIPTION
* The react/jsx-runtime import was causing `tsc-esm` to not compile and so the recent alpha builds were not actually usable as the .js extension was not being added properly. This PR fixes this issue by manually adding a script that calls the `patch` function exported by `tsc-esm`. This allows us to add an alias for this particular problematic imported and telling node to run the script instead of running the `tsc-esm` CLI directly.
* For @ricebin, also found an issue with the auth token not being attached properly (as seen in the `client.ts` changes.)