### PR TITLE
Renames prop `tokenId` to `tokenAddress` for clarity

### DIFF
--- a/src/core/error/item.ts
+++ b/src/core/error/item.ts
@@ -32,6 +32,18 @@ export class FractalSDKListItemUnknownError extends FractalSDKError {
   }
 
   getUserFacingErrorMessage() {
-    return 'An unknown error occured while buying item. Please try again in a few minutes.';
+    return 'An unknown error occured while listing item. Please try again in a few minutes.';
+  }
+}
+
+export class FractalSDKCancelListItemUnknownError extends FractalSDKError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FractalSDKCancelListItemUnknownError';
+    Object.setPrototypeOf(this, FractalSDKCancelListItemUnknownError.prototype);
+  }
+
+  getUserFacingErrorMessage() {
+    return 'An unknown error occured while cancelling item listing. Please try again in a few minutes.';
   }
 }

--- a/src/hooks/public/use-buy-item.test.tsx
+++ b/src/hooks/public/use-buy-item.test.tsx
@@ -4,7 +4,7 @@ import { useBuyItem } from 'hooks/public/use-buy-item';
 import * as useSignTransactionModule from 'hooks/public/use-sign-transaction';
 import * as itemQueriesModule from 'queries/items';
 
-const TEST_TOKEN_ID = 'test-token-id';
+const TEST_TOKEN_ADDRESS = 'test-token-address';
 const TEST_TRANSACTION = 'test-transaction';
 const TEST_TRANSACTION_SIGNATURE = 'test-transaction-signature';
 
@@ -54,12 +54,12 @@ describe('useBuyItem', () => {
       wrapper,
     });
 
-    result.current.buyItem({ tokenId: TEST_TOKEN_ID });
+    result.current.buyItem({ tokenAddress: TEST_TOKEN_ADDRESS });
 
     expect(mockMutateForBuyTransaction).toHaveBeenCalledTimes(1);
     expect(mockMutateForBuyTransaction).toHaveBeenCalledWith({
       quantity: 1,
-      tokenId: TEST_TOKEN_ID,
+      tokenId: TEST_TOKEN_ADDRESS,
     });
   });
 
@@ -68,12 +68,12 @@ describe('useBuyItem', () => {
       wrapper,
     });
 
-    result.current.buyItem({ quantity: 5, tokenId: TEST_TOKEN_ID });
+    result.current.buyItem({ quantity: 5, tokenAddress: TEST_TOKEN_ADDRESS });
 
     expect(mockMutateForBuyTransaction).toHaveBeenCalledTimes(1);
     expect(mockMutateForBuyTransaction).toHaveBeenCalledWith({
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenId: TEST_TOKEN_ADDRESS,
     });
   });
 
@@ -87,7 +87,10 @@ describe('useBuyItem', () => {
       wrapper,
     });
 
-    await result.current.buyItem({ quantity: 5, tokenId: TEST_TOKEN_ID });
+    await result.current.buyItem({
+      quantity: 5,
+      tokenAddress: TEST_TOKEN_ADDRESS,
+    });
 
     expect(mockSignTransaction).toHaveBeenCalledTimes(1);
     expect(mockSignTransaction).toHaveBeenCalledWith(SOME_TRANSACTION);
@@ -102,7 +105,7 @@ describe('useBuyItem', () => {
 
     const actual = await result.current.buyItem({
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenAddress: TEST_TOKEN_ADDRESS,
     });
 
     expect(actual.signature).toEqual(SOME_SIGNATURE);

--- a/src/hooks/public/use-buy-item.ts
+++ b/src/hooks/public/use-buy-item.ts
@@ -5,14 +5,14 @@ import { useCallback } from 'react';
 
 export interface BuyItemParameters {
   /**
-   * The quantity of `tokenId`s to purchase.
+   * The quantity of `tokenAddress`s to purchase.
    *
    * Defaults to 1. (This should be 1 for all NFTs).
    */
   quantity?: number;
 
   /** The token address of the item being purchased. */
-  tokenId: string;
+  tokenAddress: string;
 }
 
 export const useBuyItem = () => {
@@ -23,12 +23,12 @@ export const useBuyItem = () => {
   const buyItem = useCallback(
     async ({
       quantity = 1,
-      tokenId,
+      tokenAddress,
     }: BuyItemParameters): Promise<{ signature: string }> => {
       try {
         const { transaction } = await generateBuyTransaction({
           quantity,
-          tokenId,
+          tokenId: tokenAddress,
         });
         const { signature } = await signTransaction(transaction);
         return { signature };
@@ -37,7 +37,7 @@ export const useBuyItem = () => {
           throw err;
         }
         throw new FractalSDKBuyItemUnknownError(
-          `An unknown error occured while attempting to buy ${tokenId}. ` +
+          `An unknown error occured while attempting to buy ${tokenAddress}. ` +
             `err = ${err}`,
         );
       }

--- a/src/hooks/public/use-cancel-list-item.test.tsx
+++ b/src/hooks/public/use-cancel-list-item.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { FractalSDKContextProvider } from 'context/fractal-sdk-context';
+import { useCancelListItem } from 'hooks/public/use-cancel-list-item';
+import * as useSignTransactionModule from 'hooks/public/use-sign-transaction';
+import * as itemQueriesModule from 'queries/items';
+
+const TEST_TOKEN_ID = 'test-token-id';
+const TEST_TRANSACTION = 'test-transaction';
+const TEST_TRANSACTION_SIGNATURE = 'test-transaction-signature';
+
+describe('useCancelListItem', () => {
+  let wrapper: React.FC;
+  let spyUseGenerateCancelListTransactionMutation: jest.SpyInstance;
+  let spyUseSignTransaction: jest.SpyInstance;
+  let mockMutateForCancelListTransaction: jest.Mock;
+  let mockSignTransaction: jest.Mock;
+
+  beforeEach(() => {
+    mockMutateForCancelListTransaction = jest.fn();
+    mockMutateForCancelListTransaction.mockResolvedValue({
+      transaction: TEST_TRANSACTION,
+    });
+
+    mockSignTransaction = jest.fn();
+    mockSignTransaction.mockResolvedValue({
+      signature: TEST_TRANSACTION_SIGNATURE,
+    });
+
+    spyUseGenerateCancelListTransactionMutation = jest.spyOn(
+      itemQueriesModule,
+      'useGenerateCancelListTransactionMutation',
+    );
+    spyUseGenerateCancelListTransactionMutation.mockReturnValue({
+      mutateAsync: mockMutateForCancelListTransaction,
+    });
+
+    spyUseSignTransaction = jest.spyOn(
+      useSignTransactionModule,
+      'useSignTransaction',
+    );
+    spyUseSignTransaction.mockReturnValue({
+      signTransaction: mockSignTransaction,
+    });
+
+    wrapper = ({ children }) => (
+      <FractalSDKContextProvider clientId="abc">
+        {children}
+      </FractalSDKContextProvider>
+    );
+  });
+
+  it('returns a function that generates a transaction', () => {
+    const { result } = renderHook(() => useCancelListItem(), {
+      wrapper,
+    });
+
+    result.current.cancelListItem({ tokenId: TEST_TOKEN_ID });
+
+    expect(mockMutateForCancelListTransaction).toHaveBeenCalledTimes(1);
+    expect(mockMutateForCancelListTransaction).toHaveBeenCalledWith({
+      quantity: 1,
+      tokenId: TEST_TOKEN_ID,
+    });
+  });
+
+  it('returns a function that relays the correct quantity', () => {
+    const { result } = renderHook(() => useCancelListItem(), {
+      wrapper,
+    });
+
+    result.current.cancelListItem({ quantity: 5, tokenId: TEST_TOKEN_ID });
+
+    expect(mockMutateForCancelListTransaction).toHaveBeenCalledTimes(1);
+    expect(mockMutateForCancelListTransaction).toHaveBeenCalledWith({
+      quantity: 5,
+      tokenId: TEST_TOKEN_ID,
+    });
+  });
+
+  it('returns a function that attempts to sign the transaction', async () => {
+    const SOME_TRANSACTION = 'some-transaction';
+    mockMutateForCancelListTransaction.mockResolvedValue({
+      transaction: SOME_TRANSACTION,
+    });
+
+    const { result } = renderHook(() => useCancelListItem(), {
+      wrapper,
+    });
+
+    await result.current.cancelListItem({
+      quantity: 5,
+      tokenId: TEST_TOKEN_ID,
+    });
+
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSignTransaction).toHaveBeenCalledWith(SOME_TRANSACTION);
+  });
+
+  it('returns a function that resolves to the transaction signature', async () => {
+    const SOME_SIGNATURE = 'some-signature';
+    mockSignTransaction.mockResolvedValue({ signature: SOME_SIGNATURE });
+    const { result } = renderHook(() => useCancelListItem(), {
+      wrapper,
+    });
+
+    const actual = await result.current.cancelListItem({
+      quantity: 5,
+      tokenId: TEST_TOKEN_ID,
+    });
+
+    expect(actual.signature).toEqual(SOME_SIGNATURE);
+  });
+});

--- a/src/hooks/public/use-cancel-list-item.test.tsx
+++ b/src/hooks/public/use-cancel-list-item.test.tsx
@@ -4,7 +4,7 @@ import { useCancelListItem } from 'hooks/public/use-cancel-list-item';
 import * as useSignTransactionModule from 'hooks/public/use-sign-transaction';
 import * as itemQueriesModule from 'queries/items';
 
-const TEST_TOKEN_ID = 'test-token-id';
+const TEST_TOKEN_ADDRESS = 'test-token-address';
 const TEST_TRANSACTION = 'test-transaction';
 const TEST_TRANSACTION_SIGNATURE = 'test-transaction-signature';
 
@@ -54,12 +54,12 @@ describe('useCancelListItem', () => {
       wrapper,
     });
 
-    result.current.cancelListItem({ tokenId: TEST_TOKEN_ID });
+    result.current.cancelListItem({ tokenAddress: TEST_TOKEN_ADDRESS });
 
     expect(mockMutateForCancelListTransaction).toHaveBeenCalledTimes(1);
     expect(mockMutateForCancelListTransaction).toHaveBeenCalledWith({
       quantity: 1,
-      tokenId: TEST_TOKEN_ID,
+      tokenId: TEST_TOKEN_ADDRESS,
     });
   });
 
@@ -68,12 +68,15 @@ describe('useCancelListItem', () => {
       wrapper,
     });
 
-    result.current.cancelListItem({ quantity: 5, tokenId: TEST_TOKEN_ID });
+    result.current.cancelListItem({
+      quantity: 5,
+      tokenAddress: TEST_TOKEN_ADDRESS,
+    });
 
     expect(mockMutateForCancelListTransaction).toHaveBeenCalledTimes(1);
     expect(mockMutateForCancelListTransaction).toHaveBeenCalledWith({
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenId: TEST_TOKEN_ADDRESS,
     });
   });
 
@@ -89,7 +92,7 @@ describe('useCancelListItem', () => {
 
     await result.current.cancelListItem({
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenAddress: TEST_TOKEN_ADDRESS,
     });
 
     expect(mockSignTransaction).toHaveBeenCalledTimes(1);
@@ -105,7 +108,7 @@ describe('useCancelListItem', () => {
 
     const actual = await result.current.cancelListItem({
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenAddress: TEST_TOKEN_ADDRESS,
     });
 
     expect(actual.signature).toEqual(SOME_SIGNATURE);

--- a/src/hooks/public/use-cancel-list-item.ts
+++ b/src/hooks/public/use-cancel-list-item.ts
@@ -1,0 +1,52 @@
+import {
+  FractalSDKCancelListItemUnknownError,
+  FractalSDKError,
+} from 'core/error';
+import { useSignTransaction } from 'hooks/public/use-sign-transaction';
+import { useGenerateCancelListTransactionMutation } from 'queries/items';
+import { useCallback } from 'react';
+
+export interface CancelListItemParameters {
+  /**
+   * The quantity of `tokenId`s to cancel.
+   *
+   * Defaults to 1. (This should be 1 for all NFTs).
+   */
+  quantity?: number;
+
+  /** The token address of the item being cancelled. */
+  tokenId: string;
+}
+
+export const useCancelListItem = () => {
+  const { mutateAsync: generateCancelListTransaction } =
+    useGenerateCancelListTransactionMutation();
+  const { signTransaction } = useSignTransaction();
+
+  const cancelListItem = useCallback(
+    async ({
+      quantity = 1,
+      tokenId,
+    }: CancelListItemParameters): Promise<{ signature: string }> => {
+      try {
+        const { transaction } = await generateCancelListTransaction({
+          quantity,
+          tokenId,
+        });
+        const { signature } = await signTransaction(transaction);
+        return { signature };
+      } catch (err: unknown) {
+        if (err instanceof FractalSDKError) {
+          throw err;
+        }
+        throw new FractalSDKCancelListItemUnknownError(
+          `An unknown error occured while attempting to buy ${tokenId}. ` +
+            `err = ${err}`,
+        );
+      }
+    },
+    [],
+  );
+
+  return { cancelListItem };
+};

--- a/src/hooks/public/use-cancel-list-item.ts
+++ b/src/hooks/public/use-cancel-list-item.ts
@@ -15,7 +15,7 @@ export interface CancelListItemParameters {
   quantity?: number;
 
   /** The token address of the item being cancelled. */
-  tokenId: string;
+  tokenAddress: string;
 }
 
 export const useCancelListItem = () => {
@@ -26,12 +26,12 @@ export const useCancelListItem = () => {
   const cancelListItem = useCallback(
     async ({
       quantity = 1,
-      tokenId,
+      tokenAddress,
     }: CancelListItemParameters): Promise<{ signature: string }> => {
       try {
         const { transaction } = await generateCancelListTransaction({
           quantity,
-          tokenId,
+          tokenId: tokenAddress,
         });
         const { signature } = await signTransaction(transaction);
         return { signature };
@@ -40,7 +40,7 @@ export const useCancelListItem = () => {
           throw err;
         }
         throw new FractalSDKCancelListItemUnknownError(
-          `An unknown error occured while attempting to buy ${tokenId}. ` +
+          `An unknown error occured while attempting to buy ${tokenAddress}. ` +
             `err = ${err}`,
         );
       }

--- a/src/hooks/public/use-list-item.test.tsx
+++ b/src/hooks/public/use-list-item.test.tsx
@@ -4,7 +4,7 @@ import { useListItem } from 'hooks/public/use-list-item';
 import * as useSignTransactionModule from 'hooks/public/use-sign-transaction';
 import * as itemQueriesModule from 'queries/items';
 
-const TEST_TOKEN_ID = 'test-token-id';
+const TEST_TOKEN_ADDRESS = 'test-token-address';
 const TEST_TRANSACTION = 'test-transaction';
 const TEST_TRANSACTION_SIGNATURE = 'test-transaction-signature';
 
@@ -54,13 +54,16 @@ describe('useListItem', () => {
       wrapper,
     });
 
-    result.current.listItem({ price: '0.02', tokenId: TEST_TOKEN_ID });
+    result.current.listItem({
+      price: '0.02',
+      tokenAddress: TEST_TOKEN_ADDRESS,
+    });
 
     expect(mockMutateForListTransaction).toHaveBeenCalledTimes(1);
     expect(mockMutateForListTransaction).toHaveBeenCalledWith({
       price: '0.02',
       quantity: 1,
-      tokenId: TEST_TOKEN_ID,
+      tokenId: TEST_TOKEN_ADDRESS,
     });
   });
 
@@ -72,7 +75,7 @@ describe('useListItem', () => {
     result.current.listItem({
       price: '0.02',
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenAddress: TEST_TOKEN_ADDRESS,
     });
 
     expect(mockMutateForListTransaction).toHaveBeenCalledTimes(1);
@@ -91,7 +94,7 @@ describe('useListItem', () => {
     result.current.listItem({
       price: '0.53',
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenAddress: TEST_TOKEN_ADDRESS,
     });
 
     expect(mockMutateForListTransaction).toHaveBeenCalledTimes(1);
@@ -115,7 +118,7 @@ describe('useListItem', () => {
     await result.current.listItem({
       price: '0.02',
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenAddress: TEST_TOKEN_ADDRESS,
     });
 
     expect(mockSignTransaction).toHaveBeenCalledTimes(1);
@@ -132,7 +135,7 @@ describe('useListItem', () => {
     const actual = await result.current.listItem({
       price: '0.02',
       quantity: 5,
-      tokenId: TEST_TOKEN_ID,
+      tokenAddress: TEST_TOKEN_ADDRESS,
     });
 
     expect(actual.signature).toEqual(SOME_SIGNATURE);

--- a/src/hooks/public/use-list-item.ts
+++ b/src/hooks/public/use-list-item.ts
@@ -8,14 +8,14 @@ export interface ListItemParameters {
   price: string;
 
   /**
-   * The quantity of `tokenId`s to purchase.
+   * The quantity of `tokenAddress`s to purchase.
    *
    * Defaults to 1. (This should be 1 for all NFTs).
    */
   quantity?: number;
 
   /** The token address of the item being purchased. */
-  tokenId: string;
+  tokenAddress: string;
 }
 
 export const useListItem = () => {
@@ -27,13 +27,13 @@ export const useListItem = () => {
     async ({
       price,
       quantity = 1,
-      tokenId,
+      tokenAddress,
     }: ListItemParameters): Promise<{ signature: string }> => {
       try {
         const { transaction } = await generateListTransaction({
           price,
           quantity,
-          tokenId,
+          tokenId: tokenAddress,
         });
         const { signature } = await signTransaction(transaction);
         return { signature };
@@ -42,7 +42,7 @@ export const useListItem = () => {
           throw err;
         }
         throw new FractalSDKListItemUnknownError(
-          `An unknown error occured while attempting to buy ${tokenId}. ` +
+          `An unknown error occured while attempting to buy ${tokenAddress}. ` +
             `err = ${err}`,
         );
       }

--- a/src/hooks/public/use-list-item.ts
+++ b/src/hooks/public/use-list-item.ts
@@ -1,4 +1,4 @@
-import { FractalSDKBuyItemUnknownError, FractalSDKError } from 'core/error';
+import { FractalSDKError, FractalSDKListItemUnknownError } from 'core/error';
 import { useSignTransaction } from 'hooks/public/use-sign-transaction';
 import { useGenerateListTransactionMutation } from 'queries/items';
 import { useCallback } from 'react';
@@ -41,7 +41,7 @@ export const useListItem = () => {
         if (err instanceof FractalSDKError) {
           throw err;
         }
-        throw new FractalSDKBuyItemUnknownError(
+        throw new FractalSDKListItemUnknownError(
           `An unknown error occured while attempting to buy ${tokenId}. ` +
             `err = ${err}`,
         );


### PR DESCRIPTION
This PR is stacked on #77. See [this commit](https://github.com/fractalwagmi/react-sdk/pull/78/commits/87d8175c04958dd0957e18fba12ac938341088ee) for relevant diff.