### PR TITLE
1.0.4 - Fixes CSS import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractalwagmi/react-sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "React SDK for signing in with Fractal",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,1 @@
-@import '../node_modules/@fontsource/quattrocento-sans/700.css';
+@import 'node_modules/@fontsource/quattrocento-sans/700.css';


### PR DESCRIPTION
The CSS import path was not working. I tested this change by publishing an alpha version to npm and requiring it from the react-sdk-demo repo.