### PR TITLE
Adds docs for transaction status fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ interface Props {
   onFail: () => void;
 }
 
-export function YourComponent({ tokenAddress, onComplete, onFail }: Props) {
+export function BuyItem({ tokenAddress, onComplete, onFail }: Props) {
   const { buyItem } = useBuyItem();
   const { waitForTransaction } = useWaitForTransaction();
 
@@ -456,7 +456,7 @@ export function YourComponent({ tokenAddress, onComplete, onFail }: Props) {
     }
   };
 
-  return <button onClick={handleClick}>...</button>;
+  return <button onClick={handleClick}>Buy Item</button>;
 }
 ```
 
@@ -470,7 +470,7 @@ interface Props {
   transactionSignature: string;
 }
 
-export function YourComponent({ transactionSignature }: Props) {
+export function TransactionStatusDisplay({ transactionSignature }: Props) {
   const { status, error } = useTransactionStatus(transactionSignature);
 
   if (error) {

--- a/README.md
+++ b/README.md
@@ -412,13 +412,15 @@ throw the following error classes:
 
 ### Waiting for a Transaction To Post To The Chain
 
-A signed and sent transaction can take a variable amount of time to post to the
-chain. For this reason, we always quickly resolve the signature after a user
-approves a transaction.
+A signed transaction that is sent to the chain can take a variable amount of
+time to post to the chain. All of the tranasction hooks we expose like
+`useSignTransaction` and `useBuyItem` return a callback that resolves to a
+transaction signature once the user has approved the transaction, not
+when the transaction has posted to the chain.
 
 There will be cases where you want to block, or want to add a UI affordance for
-a "pending" transaction state while the transaction is being posted to the
-chain. For this, you can use one of the following hooks:
+a "pending" transaction state (like a loading spinner) while the transaction is
+being posted to the chain. For this, you can use one of the following hooks:
 
 - `useWaitForTransaction` - returns an async callback
 - `useTransactionStatus` - returns an updating status object


### PR DESCRIPTION
I've decided to first publish the docs as a way to formalize the API I intend to expose before implementing.

See [README preview](https://github.com/fractalwagmi/react-sdk/tree/kan/eng-1039#waiting-for-a-transaction-to-post-to-the-chain)