### PR TITLE
Adds `useGetTransactionStatusPollerQuery` hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@emotion/css": "^11.10.0",
         "@fontsource/quattrocento-sans": "^4.5.9",
-        "@fractalwagmi/fractal-auth-private-web-sdk-api": "^0.0.2",
-        "@fractalwagmi/fractal-sdk-websdk-api": "^0.0.3",
+        "@fractalwagmi/fractal-auth-private-web-sdk-api": "^0.0.3",
+        "@fractalwagmi/fractal-sdk-websdk-api": "^0.0.6",
         "@fractalwagmi/popup-connection": "^1.0.10",
         "@fractalwagmi/ts-api": "^0.0.2",
         "@fractalwagmi/ts-auth-api": "^0.0.1",
@@ -728,14 +728,14 @@
       "license": "MIT"
     },
     "node_modules/@fractalwagmi/fractal-auth-private-web-sdk-api": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-auth-private-web-sdk-api/-/fractal-auth-private-web-sdk-api-0.0.2.tgz",
-      "integrity": "sha512-R/fC4W0bSq8MzEeaOwB/ZqfXalzB71Qv1aJPY0S+IyaFQeh75MN+Sd29RGDPQ+U46bpVDoNzPk8Fh6gJTQ1wJw=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-auth-private-web-sdk-api/-/fractal-auth-private-web-sdk-api-0.0.3.tgz",
+      "integrity": "sha512-T7PJ01wl9T+7e90/Z0LeaSYf1uyDE9FqcNGA4393wX7hA1JF8thDJkd9JXdDdhrjD4Gx/QQwTkXsP+0DnaXWnw=="
     },
     "node_modules/@fractalwagmi/fractal-sdk-websdk-api": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-sdk-websdk-api/-/fractal-sdk-websdk-api-0.0.3.tgz",
-      "integrity": "sha512-L8OqucJE1fQGCkzSoUZ7bvr0hr1PGprTKXR0TbLmNZIKwJcFzvvGZOUHWxKp6c5FB77uNelCPW5POU1vhulfQQ=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-sdk-websdk-api/-/fractal-sdk-websdk-api-0.0.6.tgz",
+      "integrity": "sha512-o6V61EPOmvBtsi7Z+kBl0EuKc6ZiY6qgUrlZaL0JtrVhi4HwIxdabPLNuSCrhKBH8gZ2D5+XABTobiUqYRHM8g=="
     },
     "node_modules/@fractalwagmi/popup-connection": {
       "version": "1.0.10",
@@ -11228,14 +11228,14 @@
       "version": "4.5.9"
     },
     "@fractalwagmi/fractal-auth-private-web-sdk-api": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-auth-private-web-sdk-api/-/fractal-auth-private-web-sdk-api-0.0.2.tgz",
-      "integrity": "sha512-R/fC4W0bSq8MzEeaOwB/ZqfXalzB71Qv1aJPY0S+IyaFQeh75MN+Sd29RGDPQ+U46bpVDoNzPk8Fh6gJTQ1wJw=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-auth-private-web-sdk-api/-/fractal-auth-private-web-sdk-api-0.0.3.tgz",
+      "integrity": "sha512-T7PJ01wl9T+7e90/Z0LeaSYf1uyDE9FqcNGA4393wX7hA1JF8thDJkd9JXdDdhrjD4Gx/QQwTkXsP+0DnaXWnw=="
     },
     "@fractalwagmi/fractal-sdk-websdk-api": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-sdk-websdk-api/-/fractal-sdk-websdk-api-0.0.3.tgz",
-      "integrity": "sha512-L8OqucJE1fQGCkzSoUZ7bvr0hr1PGprTKXR0TbLmNZIKwJcFzvvGZOUHWxKp6c5FB77uNelCPW5POU1vhulfQQ=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-sdk-websdk-api/-/fractal-sdk-websdk-api-0.0.6.tgz",
+      "integrity": "sha512-o6V61EPOmvBtsi7Z+kBl0EuKc6ZiY6qgUrlZaL0JtrVhi4HwIxdabPLNuSCrhKBH8gZ2D5+XABTobiUqYRHM8g=="
     },
     "@fractalwagmi/popup-connection": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   "dependencies": {
     "@emotion/css": "^11.10.0",
     "@fontsource/quattrocento-sans": "^4.5.9",
-    "@fractalwagmi/fractal-auth-private-web-sdk-api": "^0.0.2",
-    "@fractalwagmi/fractal-sdk-websdk-api": "^0.0.3",
+    "@fractalwagmi/fractal-auth-private-web-sdk-api": "^0.0.3",
+    "@fractalwagmi/fractal-sdk-websdk-api": "^0.0.6",
     "@fractalwagmi/popup-connection": "^1.0.10",
     "@fractalwagmi/ts-api": "^0.0.2",
     "@fractalwagmi/ts-auth-api": "^0.0.1",

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -1,4 +1,5 @@
 export enum ApiFeature {
   COINS = 'COINS',
   ITEMS = 'ITEMS',
+  TRANSACTION = 'TRANSACTION',
 }

--- a/src/queries/transaction.test.tsx
+++ b/src/queries/transaction.test.tsx
@@ -1,0 +1,162 @@
+import { FractalWebsdkTransactionGetTransactionStatusResponse } from '@fractalwagmi/fractal-sdk-websdk-api';
+import * as reactQuery from '@tanstack/react-query';
+import { renderHook, act } from '@testing-library/react-hooks/dom';
+import { webSdkApiClient } from 'core/api/client';
+import { TEST_FRACTAL_USER } from 'hooks/__data__/constants';
+import { useUser } from 'hooks/public/use-user';
+import { useGetTransactionStatusPollerQuery } from 'queries/transaction';
+
+jest.mock('hooks/public/use-user');
+jest.mock('core/api/client');
+jest.mock('core/api/client');
+
+const TWO_SECONDS_MS = 2000;
+const TEST_SIGNATURE = 'test-signature';
+
+let mockUseUser: jest.Mock;
+let mockGetTransactionStatus: jest.Mock;
+let spyUseQuery: jest.SpyInstance;
+
+let queryClient: reactQuery.QueryClient;
+let wrapper: React.FC;
+
+beforeEach(() => {
+  queryClient = new reactQuery.QueryClient();
+  wrapper = ({ children }) => (
+    <reactQuery.QueryClientProvider client={queryClient}>
+      {children}
+    </reactQuery.QueryClientProvider>
+  );
+
+  mockUseUser = useUser as jest.Mock;
+  mockUseUser.mockReturnValue({
+    data: TEST_FRACTAL_USER,
+  });
+
+  mockGetTransactionStatus = webSdkApiClient.websdk
+    .getTransactionStatus as jest.Mock;
+  mockGetTransactionStatus.mockResolvedValue({
+    data: {
+      confirmed: {},
+    } as FractalWebsdkTransactionGetTransactionStatusResponse,
+  });
+
+  spyUseQuery = jest.spyOn(reactQuery, 'useQuery');
+});
+
+afterEach(() => {
+  mockUseUser.mockReset();
+  mockGetTransactionStatus.mockReset();
+  spyUseQuery.mockRestore();
+  jest.resetAllMocks();
+});
+
+describe('useGetTransactionStatusPoller', () => {
+  it('does not poll when there is no user', () => {
+    mockUseUser.mockReturnValue({ data: undefined });
+
+    renderHook(() => useGetTransactionStatusPollerQuery(TEST_SIGNATURE), {
+      wrapper,
+    });
+
+    expect(spyUseQuery).toHaveBeenCalledTimes(1);
+    expect(spyUseQuery).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Function),
+      expect.objectContaining({
+        enabled: false,
+      }),
+    );
+  });
+
+  it('removes the query cache when a user logs out', () => {
+    const mockRemove = jest.fn();
+    spyUseQuery.mockReturnValue({
+      data: {
+        confirmed: {},
+      },
+      error: undefined,
+      remove: mockRemove,
+    });
+    const { rerender } = renderHook(
+      () => useGetTransactionStatusPollerQuery(TEST_SIGNATURE),
+      { wrapper },
+    );
+    expect(mockRemove).not.toHaveBeenCalled();
+
+    mockUseUser.mockReturnValue({ data: undefined });
+    act(() => {
+      rerender();
+    });
+
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls for the transaction status', async () => {
+    const { result, waitForValueToChange } = renderHook(
+      () => useGetTransactionStatusPollerQuery(TEST_SIGNATURE),
+      {
+        wrapper,
+      },
+    );
+    await waitForValueToChange(() => result.current.data);
+
+    expect(spyUseQuery).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      expect.any(Function),
+      expect.objectContaining({
+        refetchInterval: TWO_SECONDS_MS,
+      }),
+    );
+  });
+
+  it('stops polling after transaction status is returned', async () => {
+    const { result, waitForValueToChange } = renderHook(
+      () => useGetTransactionStatusPollerQuery(TEST_SIGNATURE),
+      { wrapper },
+    );
+    expect(spyUseQuery).toHaveBeenCalledTimes(1);
+    expect(spyUseQuery).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Function),
+      expect.objectContaining({
+        refetchInterval: TWO_SECONDS_MS,
+      }),
+    );
+    await waitForValueToChange(() => result.current.data);
+
+    mockGetTransactionStatus.mockResolvedValue({
+      data: {
+        confirmed: { success: true },
+      },
+    });
+    result.current.refetch();
+    await waitForValueToChange(() => result.current.data);
+
+    expect(spyUseQuery).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      expect.any(Function),
+      expect.objectContaining({
+        refetchInterval: false,
+      }),
+    );
+  });
+
+  it('does not fetch when window is refocused', async () => {
+    const { result, waitForValueToChange } = renderHook(
+      () => useGetTransactionStatusPollerQuery(TEST_SIGNATURE),
+      {
+        wrapper,
+      },
+    );
+    await waitForValueToChange(() => result.current.data);
+
+    expect(spyUseQuery).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Function),
+      expect.objectContaining({
+        refetchOnWindowFocus: false,
+      }),
+    );
+  });
+});

--- a/src/queries/transaction.test.tsx
+++ b/src/queries/transaction.test.tsx
@@ -37,7 +37,7 @@ beforeEach(() => {
     .getTransactionStatus as jest.Mock;
   mockGetTransactionStatus.mockResolvedValue({
     data: {
-      confirmed: {},
+      confirmed: undefined,
     } as FractalWebsdkTransactionGetTransactionStatusResponse,
   });
 
@@ -73,7 +73,7 @@ describe('useGetTransactionStatusPoller', () => {
     const mockRemove = jest.fn();
     spyUseQuery.mockReturnValue({
       data: {
-        confirmed: {},
+        confirmed: undefined,
       },
       error: undefined,
       remove: mockRemove,
@@ -115,8 +115,7 @@ describe('useGetTransactionStatusPoller', () => {
       () => useGetTransactionStatusPollerQuery(TEST_SIGNATURE),
       { wrapper },
     );
-    expect(spyUseQuery).toHaveBeenCalledTimes(1);
-    expect(spyUseQuery).toHaveBeenCalledWith(
+    expect(spyUseQuery).toHaveBeenLastCalledWith(
       expect.any(Array),
       expect.any(Function),
       expect.objectContaining({

--- a/src/queries/transaction.ts
+++ b/src/queries/transaction.ts
@@ -4,6 +4,7 @@ import { webSdkApiClient } from 'core/api/client';
 import { ApiFeature } from 'core/api/types';
 import { FractalSDKGetCoinsUnknownError } from 'core/error';
 import { useUser } from 'hooks/public/use-user';
+import { isNotNullOrUndefined } from 'lib/util/guards';
 import { secondsInMs } from 'lib/util/time';
 import { useEffect, useState } from 'react';
 
@@ -21,23 +22,23 @@ export const TransactionApiKeys = {
 };
 
 export const useGetTransactionStatusPollerQuery = (signature: string) => {
-  const [stopPolling, setStopPolling] = useState(false);
+  const [shouldPoll, setShouldPoll] = useState(true);
   const { data: user } = useUser();
   const query = useQuery(
     TransactionApiKeys.getTransactionStatus(signature),
     async () => TransactionApi.getTransactionStatus(signature),
     {
-      enabled: user !== undefined,
-      refetchInterval: stopPolling ? false : secondsInMs(2),
+      enabled: isNotNullOrUndefined(user),
+      refetchInterval: shouldPoll ? secondsInMs(2) : false,
       refetchOnWindowFocus: false,
     },
   );
 
   useEffect(() => {
-    if (!stopPolling && query.data?.confirmed?.success !== undefined) {
-      setStopPolling(true);
+    if (shouldPoll && query.data?.confirmed?.success !== undefined) {
+      setShouldPoll(false);
     }
-  }, [stopPolling, query]);
+  }, [shouldPoll, query]);
 
   useEffect(() => {
     if (user === undefined) {

--- a/src/queries/transaction.ts
+++ b/src/queries/transaction.ts
@@ -35,7 +35,8 @@ export const useGetTransactionStatusPollerQuery = (signature: string) => {
   );
 
   useEffect(() => {
-    if (shouldPoll && query.data?.confirmed?.success !== undefined) {
+    const isTransactionPending = query.data?.confirmed === undefined;
+    if (shouldPoll && !isTransactionPending) {
       setShouldPoll(false);
     }
   }, [shouldPoll, query]);

--- a/src/queries/transaction.ts
+++ b/src/queries/transaction.ts
@@ -1,0 +1,65 @@
+import { FractalWebsdkTransactionGetTransactionStatusResponse } from '@fractalwagmi/fractal-sdk-websdk-api';
+import { useQuery } from '@tanstack/react-query';
+import { webSdkApiClient } from 'core/api/client';
+import { ApiFeature } from 'core/api/types';
+import { FractalSDKGetCoinsUnknownError } from 'core/error';
+import { useUser } from 'hooks/public/use-user';
+import { secondsInMs } from 'lib/util/time';
+import { useEffect, useState } from 'react';
+
+enum TransactionApiKey {
+  GET_TRANSACTION_STATUS = 'GET_TRANSACTION_STATUS',
+}
+
+export const TransactionApiKeys = {
+  getTransactionStatus: (signature: string) =>
+    [
+      ApiFeature.TRANSACTION,
+      TransactionApiKey.GET_TRANSACTION_STATUS,
+      signature,
+    ] as const,
+};
+
+export const useGetTransactionStatusPollerQuery = (signature: string) => {
+  const [stopPolling, setStopPolling] = useState(false);
+  const { data: user } = useUser();
+  const query = useQuery(
+    TransactionApiKeys.getTransactionStatus(signature),
+    async () => TransactionApi.getTransactionStatus(signature),
+    {
+      enabled: user !== undefined,
+      refetchInterval: stopPolling ? false : secondsInMs(2),
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  useEffect(() => {
+    if (!stopPolling && query.data?.confirmed?.success !== undefined) {
+      setStopPolling(true);
+    }
+  }, [stopPolling, query]);
+
+  useEffect(() => {
+    if (user === undefined) {
+      query.remove();
+    }
+  }, [user]);
+
+  return query;
+};
+
+const TransactionApi = {
+  getTransactionStatus,
+};
+
+async function getTransactionStatus(
+  signature: string,
+): Promise<FractalWebsdkTransactionGetTransactionStatusResponse> {
+  const response = await webSdkApiClient.websdk.getTransactionStatus(signature);
+  if (response.error) {
+    throw new FractalSDKGetCoinsUnknownError(
+      `There was an error fetching coins. err = ${response.error.message}`,
+    );
+  }
+  return response.data;
+}


### PR DESCRIPTION
As title.

This is going to be used in the new `useTransactionStatus` hook I wrote the docs for in https://github.com/fractalwagmi/react-sdk/pull/92.