### PR TITLE
Adds user id as query cache key for fetching for sale items

### DIFF
--- a/src/queries/coins.ts
+++ b/src/queries/coins.ts
@@ -4,6 +4,7 @@ import { sdkApiClient } from 'core/api/client';
 import { ApiFeature } from 'core/api/types';
 import { FractalSDKGetCoinsUnknownError } from 'core/error';
 import { useUser } from 'hooks/public/use-user';
+import { isNotNullOrUndefined } from 'lib/util/guards';
 
 enum CoinApiKey {
   GET_COINS = 'GET_COINS',
@@ -20,7 +21,7 @@ export const useGetCoinsQuery = () => {
     CoinApiKeys.getCoins(user?.userId),
     async () => CoinApi.getCoins(),
     {
-      enabled: user !== undefined,
+      enabled: isNotNullOrUndefined(user),
     },
   );
 

--- a/src/queries/items.test.tsx
+++ b/src/queries/items.test.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { TEST_FRACTAL_USER } from 'hooks/__data__/constants';
+import { useUser } from 'hooks/public/use-user';
+import { useGetItemsForSaleQuery } from 'queries/items';
+
+jest.mock('@tanstack/react-query');
+jest.mock('hooks/public/use-user');
+
+let mockUseQuery: jest.Mock;
+let mockUseUser: jest.Mock;
+
+beforeEach(() => {
+  mockUseQuery = useQuery as jest.Mock;
+
+  mockUseUser = useUser as jest.Mock;
+  mockUseUser.mockReturnValue({
+    data: TEST_FRACTAL_USER,
+  });
+});
+
+afterEach(() => {
+  mockUseQuery.mockReset();
+});
+
+describe('useGetItemsForSaleQuery', () => {
+  // Ensures that logging out invalidates the cache.
+  it('uses the userId as a query cache key', () => {
+    renderHook(() =>
+      useGetItemsForSaleQuery({
+        limit: 1,
+        sortDirection: 'DESCENDING',
+        sortField: 'LIST_TIME',
+      }),
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.arrayContaining([TEST_FRACTAL_USER.userId]),
+      expect.any(Function),
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
This fixes a bug where logging out doesn't remove the stale for-sale items data in the react query client (browser cache). 

For context, listing for-sale items requires an access token, so the user needs to be logged in to see it.