### PR TITLE
Onramp: onSuccess/onError handlers

### DIFF
--- a/src/components/buy-crypto.tsx
+++ b/src/components/buy-crypto.tsx
@@ -1,8 +1,8 @@
 import { Button, ButtonProps } from 'components/button';
-import { useOnramp } from 'hooks';
+import { useOnramp, UseOnrampOptions } from 'hooks';
 import { FC, HTMLAttributes } from 'react';
 
-interface Props {
+interface Props extends UseOnrampOptions {
   /**
    * Any additional props for <button> that should be passed to the default
    * sign-in button.
@@ -16,8 +16,17 @@ interface Props {
   theme?: ButtonProps['theme'];
 }
 
-export const BuyCrypto: FC<Props> = ({ buttonProps = {}, theme = 'light' }) => {
-  const { openOnrampWindow } = useOnramp({ theme });
+export const BuyCrypto: FC<Props> = ({
+  buttonProps = {},
+  theme = 'light',
+  onRejected,
+  onFulfillmentComplete,
+}) => {
+  const { openOnrampWindow } = useOnramp({
+    onFulfillmentComplete,
+    onRejected,
+    theme,
+  });
 
   return (
     <Button {...buttonProps} theme={theme} onClick={openOnrampWindow}>

--- a/src/core/error/onramp.ts
+++ b/src/core/error/onramp.ts
@@ -1,0 +1,14 @@
+import { FractalSDKError } from 'core/error/base';
+
+export class FractalSDKOnrampUnknownError extends FractalSDKError {
+  name: string;
+  constructor(message: string) {
+    super(message);
+    this.name = 'FractalSDKOnrampUnknownError';
+    Object.setPrototypeOf(this, FractalSDKOnrampUnknownError.prototype);
+  }
+
+  getUserFacingErrorMessage() {
+    return 'The onramp session concluded with an unknown error.';
+  }
+}

--- a/src/hooks/public/types.ts
+++ b/src/hooks/public/types.ts
@@ -5,3 +5,5 @@ export interface PublicDataHookResponse<T> {
   error: FractalSDKError | undefined;
   refetch: () => void;
 }
+
+export type Awaitable<T> = T | Promise<T>;

--- a/src/hooks/public/use-onramp.ts
+++ b/src/hooks/public/use-onramp.ts
@@ -1,27 +1,92 @@
 import { Platform, usePopupConnection } from '@fractalwagmi/popup-connection';
 import { ButtonProps } from 'components/button';
 import { FractalSDKContext } from 'context/fractal-sdk-context';
-import { useCallback, useContext } from 'react';
+import { FractalSDKError } from 'core/error';
+import { FractalSDKOnrampUnknownError } from 'core/error/onramp';
+import { Awaitable } from 'hooks/public/types';
+import { useCallback, useContext, useRef } from 'react';
 
 const ONRAMP_URL = 'https://fractal.is/onramp';
-const POPUP_HEIGHT_PX = 672;
 
-interface UseOnrampOptions {
+const MIN_POPUP_HEIGHT_PX = 672;
+const MAX_POPUP_WIDTH_PX = 850;
+
+type OnrampErrors = FractalSDKError | FractalSDKOnrampUnknownError;
+
+export interface UseOnrampOptions {
+  /**
+   * A callback to invoke after an onramp session has been fulfilled, meaning
+   * that payment was processed and funds were delivered to the user's wallet.
+   */
+  onFulfillmentComplete?: () => Awaitable<void>;
+  /**
+   * A callback to invoke after an onramp session was rejected for a known
+   * reason. Possible reasons may include KYC failure, sanctions screening
+   * issues, fraud checks.
+   */
+  onRejected?: (err: OnrampErrors) => Awaitable<void>;
+  /**
+   * The button style variant to use.
+   *
+   * Possible values: 'light' | 'dark'. Defaults to 'light'.
+   */
   theme?: ButtonProps['theme'];
 }
 
-export const useOnramp = (options?: UseOnrampOptions) => {
-  const { theme } = options ?? { theme: 'light' };
+export const useOnramp = (
+  { onFulfillmentComplete, onRejected, theme }: UseOnrampOptions = {
+    theme: 'light',
+  },
+) => {
   const { clientId, user } = useContext(FractalSDKContext);
+
+  const promiseResolversRef = useRef<{
+    reject: (err: OnrampErrors) => void;
+    resolve: () => void;
+  } | null>(null);
+
   const { open: openPopup } = usePopupConnection({
     enabled: !user,
-    heightPx: POPUP_HEIGHT_PX,
+    heightPx: Math.max(
+      MIN_POPUP_HEIGHT_PX,
+      Math.floor(window.innerHeight * 0.8),
+    ),
     platform: Platform.REACT_SDK,
+    widthPx: Math.min(MAX_POPUP_WIDTH_PX, Math.floor(window.innerWidth * 0.5)),
   });
 
-  const openOnrampWindow = useCallback(() => {
-    openPopup(`${ONRAMP_URL}?clientId=${clientId}&theme=${theme}`);
+  const openOnrampWindow = useCallback(async () => {
+    await (async () => {
+      try {
+        openPopup(`${ONRAMP_URL}?clientId=${clientId}&theme=${theme}`);
+        onFulfillmentComplete?.();
+      } catch (err: unknown) {
+        const onrampErr = asOnrampError(err);
+        if (onRejected) {
+          onRejected(onrampErr);
+          return;
+        }
+        throw onrampErr;
+      }
+    })();
+
+    return new Promise<void>((resolve, reject) => {
+      promiseResolversRef.current = {
+        reject,
+        resolve,
+      };
+    });
   }, []);
 
   return { openOnrampWindow };
 };
+
+function asOnrampError(err: unknown): OnrampErrors {
+  if (err instanceof FractalSDKError) {
+    return err;
+  }
+
+  return new FractalSDKOnrampUnknownError(
+    `An unknown error occurred during the onramp session. err = ${err}`,
+  );
+}


### PR DESCRIPTION
This PR extends onramp functionality around success/error handlers, specifically exposing events for `onFulfillmentComplete` and `onRejected`, which are both terminal statuses for an onramp session that are directly proxied through stripe.

Tested via react-sdk-demo repo. Noticed an issue around when the event itself is triggered for fullfillment (too early) - followed up w/ stripe team on slack but their fix won't necessarily affect the contents of this PR, which should remain the same.