### PR TITLE
React-based ESLint rules, enforce hook deps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,8 @@
   ],
   "extends": [
     "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:import/typescript",
     "plugin:typescript-sort-keys/recommended",
@@ -95,6 +97,10 @@
         }
       ]
     }],
-    "@typescript-eslint/prefer-includes": "warn"
+    "@typescript-eslint/prefer-includes": "warn",
+
+    // React
+    "react/react-in-jsx-scope": "off",
+    "react-hooks/exhaustive-deps": "error"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "eslint-config-prettier": "^8.4.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-react": "^7.32.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-sort-destructure-keys": "^1.4.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
         "eslint-plugin-typescript-sort-keys": "^2.1.0",
@@ -2103,14 +2105,15 @@
       "license": "Python-2.0"
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -2142,6 +2145,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "node_modules/assert": {
@@ -2868,6 +2902,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
       "license": "MIT",
@@ -3155,6 +3198,85 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.32.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.4",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-sort-destructure-keys": {
@@ -4141,8 +4263,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "license": "MIT",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -5705,6 +5828,19 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/jwt-decode": {
       "version": "3.1.2",
       "license": "MIT"
@@ -6102,7 +6238,6 @@
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6773,7 +6908,6 @@
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6825,14 +6959,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.values": {
-      "version": "1.1.5",
+    "node_modules/object.entries": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7221,6 +7400,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -8014,6 +8210,25 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend": {
@@ -10243,13 +10458,15 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.4",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       }
     },
@@ -10264,6 +10481,31 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.0"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "assert": {
@@ -10765,6 +11007,15 @@
         "unbox-primitive": "^1.0.2"
       }
     },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "es-to-primitive": {
       "version": "1.2.1",
       "requires": {
@@ -10980,6 +11231,64 @@
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
+    },
+    "eslint-plugin-react": {
+      "version": "7.32.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.4",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-sort-destructure-keys": {
       "version": "1.4.0",
@@ -11606,7 +11915,9 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.8.1",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -12745,6 +13056,16 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsx-ast-utils": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
+      }
+    },
     "jwt-decode": {
       "version": "3.1.2"
     },
@@ -13016,7 +13337,6 @@
     },
     "loose-envify": {
       "version": "1.4.0",
-      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -13380,8 +13700,7 @@
       "dev": true
     },
     "object-assign": {
-      "version": "4.1.1",
-      "peer": true
+      "version": "4.1.1"
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -13411,13 +13730,47 @@
         "object-keys": "^1.1.1"
       }
     },
-    "object.values": {
-      "version": "1.1.5",
+    "object.entries": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.values": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "once": {
@@ -13653,6 +14006,25 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
           "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+          "dev": true
+        }
+      }
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
           "dev": true
         }
       }
@@ -14167,6 +14539,22 @@
             "ansi-regex": "^6.0.1"
           }
         }
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
       }
     },
     "string.prototype.trimend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractalwagmi/react-sdk",
-  "version": "1.1.5",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractalwagmi/react-sdk",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "dependencies": {
         "@emotion/css": "^11.10.0",
         "@fontsource/quattrocento-sans": "^4.5.9",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prebuild:local": "[ ! -d node_modules/react.disabled ] || mv node_modules/react.disabled node_modules/react",
     "build:local": "npm run build",
     "postbuild:local": "[ ! -d node_modules/react ] || mv node_modules/react node_modules/react.disabled",
-    "lint": "eslint --fix",
+    "lint": "npx eslint '*/**/*.{ts,tsx,js}'",
     "prepublishOnly": "npm run test && npm run build"
   },
   "exports": {
@@ -79,6 +79,8 @@
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-sort-destructure-keys": "^1.4.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",
     "eslint-plugin-typescript-sort-keys": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractalwagmi/react-sdk",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "React SDK for signing in with Fractal",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/hooks/public/use-auth-button-props.ts
+++ b/src/hooks/public/use-auth-button-props.ts
@@ -80,7 +80,7 @@ export const useAuthButtonProps = ({
     };
 
     refreshUser();
-  }, [user, fetchingUser]);
+  }, [user, fetchingUser, fetchAndSetUser]);
 
   const signedIn = Boolean(user);
   const onClick = useCallback(() => {
@@ -91,7 +91,7 @@ export const useAuthButtonProps = ({
       setIsAuthenticating(true);
       signIn();
     }
-  }, [signedIn, signOut, signIn]);
+  }, [signedIn, signOut, onSignOut, signIn]);
 
   return {
     loading: isAuthenticating,

--- a/src/hooks/public/use-buy-item.ts
+++ b/src/hooks/public/use-buy-item.ts
@@ -42,7 +42,7 @@ export const useBuyItem = () => {
         );
       }
     },
-    [],
+    [generateBuyTransaction, signTransaction],
   );
 
   return { buyItem };

--- a/src/hooks/public/use-cancel-list-item.ts
+++ b/src/hooks/public/use-cancel-list-item.ts
@@ -45,7 +45,7 @@ export const useCancelListItem = () => {
         );
       }
     },
-    [],
+    [generateCancelListTransaction, signTransaction],
   );
 
   return { cancelListItem };

--- a/src/hooks/public/use-coins.ts
+++ b/src/hooks/public/use-coins.ts
@@ -14,7 +14,7 @@ export const useCoins = (): PublicDataHookResponse<Coin[]> => {
 
   const refetch = useCallback(() => {
     refetchQuery();
-  }, []);
+  }, [refetchQuery]);
   const coins = useMemo(() => transformCoins(data?.coins ?? []), [data?.coins]);
 
   let error: FractalSDKError | undefined;

--- a/src/hooks/public/use-items-for-sale.ts
+++ b/src/hooks/public/use-items-for-sale.ts
@@ -33,7 +33,7 @@ export const useItemsForSale = ({
   });
   const refetch = useCallback(() => {
     refetchQuery();
-  }, []);
+  }, [refetchQuery]);
   const items = useMemo(
     () =>
       data?.items === undefined ? undefined : trasnformForSaleItems(data.items),

--- a/src/hooks/public/use-items.ts
+++ b/src/hooks/public/use-items.ts
@@ -14,7 +14,7 @@ export const useItems = (): PublicDataHookResponse<Item[]> => {
 
   const refetch = useCallback(() => {
     refetchQuery();
-  }, []);
+  }, [refetchQuery]);
   const items = useMemo(
     () => (data?.items === undefined ? undefined : transformItems(data.items)),
     [data?.items],

--- a/src/hooks/public/use-list-item.ts
+++ b/src/hooks/public/use-list-item.ts
@@ -47,7 +47,7 @@ export const useListItem = () => {
         );
       }
     },
-    [],
+    [generateListTransaction, signTransaction],
   );
 
   return { listItem };

--- a/src/hooks/public/use-onramp.ts
+++ b/src/hooks/public/use-onramp.ts
@@ -102,7 +102,7 @@ export const useOnramp = (
       );
     }
     openPopup(`${ONRAMP_URL}?clientId=${clientId}&theme=${theme}`);
-  }, []);
+  }, [user, clientId, theme]);
 
   return { openOnrampWindow };
 };

--- a/src/hooks/public/use-onramp.ts
+++ b/src/hooks/public/use-onramp.ts
@@ -60,10 +60,13 @@ export const useOnramp = (
     widthPx: Math.min(MAX_POPUP_WIDTH_PX, Math.floor(window.innerWidth * 0.6)),
   });
 
-  const handleOnRejected = useCallback((err: unknown) => {
-    const onrampErr = asOnrampError(err);
-    onRejected?.(onrampErr);
-  }, []);
+  const handleOnRejected = useCallback(
+    (err: unknown) => {
+      const onrampErr = asOnrampError(err);
+      onRejected?.(onrampErr);
+    },
+    [onRejected],
+  );
 
   useEffect(() => {
     if (!connection) {
@@ -93,7 +96,7 @@ export const useOnramp = (
         connection.off(PopupEvent.ONRAMP_REJECTED, handleOnRejected);
       }
     };
-  }, [connection]);
+  }, [connection, handleOnRejected, onFulfillmentComplete, onRejected]);
 
   const openOnrampWindow = useCallback(async () => {
     if (!user) {
@@ -102,7 +105,7 @@ export const useOnramp = (
       );
     }
     openPopup(`${ONRAMP_URL}?clientId=${clientId}&theme=${theme}`);
-  }, [user, clientId, theme]);
+  }, [clientId, openPopup, theme, user]);
 
   return { openOnrampWindow };
 };

--- a/src/hooks/public/use-sign-transaction.tsx
+++ b/src/hooks/public/use-sign-transaction.tsx
@@ -139,7 +139,7 @@ export const useSignTransaction = () => {
         };
       });
     },
-    [fetchAuthorizeUrl],
+    [fetchAuthorizeUrl, open],
   );
 
   return {

--- a/src/hooks/public/use-wait-for-transaction-status.ts
+++ b/src/hooks/public/use-wait-for-transaction-status.ts
@@ -17,22 +17,25 @@ export const useWaitForTransactionStatus = (): {
   waitForTransactionStatus: (signature: string) => Promise<TransactionStatus>;
 } => {
   const pollForTransactionStatus = useTransactionStatusPoller();
-  const waitForTransactionStatus = useCallback(async (signature: string) => {
-    try {
-      const success = await pollForTransactionStatus(signature);
-      if (success) {
-        return TransactionStatus.SUCCESS;
+  const waitForTransactionStatus = useCallback(
+    async (signature: string) => {
+      try {
+        const success = await pollForTransactionStatus(signature);
+        if (success) {
+          return TransactionStatus.SUCCESS;
+        }
+        return TransactionStatus.FAIL;
+      } catch (err: unknown) {
+        if (err instanceof FractalSDKError) {
+          throw err;
+        }
+        throw new FractalSDKTransactionStatusFetchUnknownError(
+          'An unknown error occured while fetching the status of a signature',
+        );
       }
-      return TransactionStatus.FAIL;
-    } catch (err: unknown) {
-      if (err instanceof FractalSDKError) {
-        throw err;
-      }
-      throw new FractalSDKTransactionStatusFetchUnknownError(
-        'An unknown error occured while fetching the status of a signature',
-      );
-    }
-  }, []);
+    },
+    [pollForTransactionStatus],
+  );
 
   return {
     waitForTransactionStatus,

--- a/src/hooks/use-sign-in.ts
+++ b/src/hooks/use-sign-in.ts
@@ -59,7 +59,7 @@ export const useSignIn = ({
         );
       }
     }
-  }, [connection]);
+  }, [connection, getAuthUrlMutation, onSignInFailed, openPopup]);
 
   useEffect(() => {
     if (!connection) {
@@ -106,7 +106,7 @@ export const useSignIn = ({
       connection.off(PopupEvent.PROJECT_APPROVED, handleProjectApproved);
       connection.off(PopupEvent.POPUP_CLOSED, handlePopupClosed);
     };
-  }, [connection]);
+  }, [closePopup, connection, fetchAndSetUser, onSignIn, onSignInFailed]);
 
   return { signIn };
 };

--- a/src/hooks/use-user-setter.ts
+++ b/src/hooks/use-user-setter.ts
@@ -34,7 +34,7 @@ export const useUserSetter = () => {
         userWallet,
       };
     },
-    [],
+    [setUser, setUserWallet],
   );
 
   return {

--- a/src/queries/transaction.ts
+++ b/src/queries/transaction.ts
@@ -52,7 +52,7 @@ export const useGetTransactionStatusPollerQuery = (signature: string) => {
     if (user === undefined) {
       query.remove();
     }
-  }, [user]);
+  }, [query, user]);
 
   return query;
 };


### PR DESCRIPTION
We were missing eslint packages here for react-based stuff incl hooks - added those in here and updated all functionality that was missing deps to have those included for hooks like usememo/usecallback

Tested by publishing an alpha version and linking in the react-sdk-demo repo, checking that existing functionality (incl onramp) works as expected (prior to this the onramp window wasn't correctly being opened when the user changed during the session.
