### PR TITLE
Bumps version for missing onramp features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractalwagmi/react-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "React SDK for signing in with Fractal",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
This version bump is so that we can publish a new alpha package (which is intended to eventually be the latest). The last two alphas (1.2.0 and 1.2.1) was published without the onramp stuff since that code was missing in the `main` branch.