### PR TITLE
Uses `context` prop for react-query's `QueryClientProvider`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.3] - 2023-03-08
+
+- Uses custom `context` for all react query calls. This will allow consumers to
+  use react query without having to worry about conflicting contexts used by
+  the underlying `QueryClientProvider` within the SDK as well as the one that a
+  consumer sets up in their app.
+
 ## [1.2.1] - 2023-02-13
 
 - Adds a `chain` field on exported `Item` and `Coin` type.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractalwagmi/react-sdk",
-  "version": "1.2.2",
+  "version": "1.2.2-1",
   "description": "React SDK for signing in with Fractal",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractalwagmi/react-sdk",
-  "version": "1.2.2-1",
+  "version": "1.2.3",
   "description": "React SDK for signing in with Fractal",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/context/fractal-sdk-context.tsx
+++ b/src/context/fractal-sdk-context.tsx
@@ -3,7 +3,8 @@ import { clearIdAndTokenInLS } from 'core/token';
 import { createContext, useCallback, useState } from 'react';
 import { User, UserWallet } from 'types';
 
-const queryClient = new QueryClient();
+export const queryContext = createContext<QueryClient | undefined>(undefined);
+export const queryClient = new QueryClient();
 
 interface FractalSDKContextState {
   clientId: string;
@@ -53,7 +54,9 @@ export function FractalSDKContextProvider({
         userWallet,
       }}
     >
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient} context={queryContext}>
+        {children}
+      </QueryClientProvider>
     </FractalSDKContext.Provider>
   );
 }

--- a/src/queries/auth.ts
+++ b/src/queries/auth.ts
@@ -1,5 +1,6 @@
 import { FractalAuthPrivateWebSdkGetApprovalUrlResponse } from '@fractalwagmi/fractal-auth-private-web-sdk-api';
 import { useMutation } from '@tanstack/react-query';
+import { queryContext } from 'context/fractal-sdk-context';
 import { authPrivateWebSdkApiClient } from 'core/api/client';
 import { ApiFeature } from 'core/api/types';
 import { FractalSDKAuthenticationUnknownError } from 'core/error';
@@ -20,8 +21,12 @@ export const useGetAuthUrlMutation = (
   clientId: string,
   scopes: Scope[] = DEFAULT_SCOPE,
 ) => {
-  return useMutation(AuthApiKeys.getAuthUrl(clientId, scopes), async () =>
-    AuthApi.getAuthUrl(clientId, scopes),
+  return useMutation(
+    AuthApiKeys.getAuthUrl(clientId, scopes),
+    async () => AuthApi.getAuthUrl(clientId, scopes),
+    {
+      context: queryContext,
+    },
   );
 };
 

--- a/src/queries/coins.ts
+++ b/src/queries/coins.ts
@@ -1,5 +1,6 @@
 import { FractalSdkWalletGetCoinsResponse } from '@fractalwagmi/fractal-sdk-public-api';
 import { useQuery } from '@tanstack/react-query';
+import { queryContext } from 'context/fractal-sdk-context';
 import { sdkApiClient } from 'core/api/client';
 import { ApiFeature } from 'core/api/types';
 import { FractalSDKGetCoinsUnknownError } from 'core/error';
@@ -21,6 +22,7 @@ export const useGetCoinsQuery = () => {
     CoinApiKeys.getCoins(user?.userId),
     async () => CoinApi.getCoins(),
     {
+      context: queryContext,
       enabled: isNotNullOrUndefined(user),
     },
   );

--- a/src/queries/items.ts
+++ b/src/queries/items.ts
@@ -6,6 +6,7 @@ import {
 } from '@fractalwagmi/fractal-sdk-public-api';
 import { FractalWebsdkMarketplaceGetForSaleItemsResponse } from '@fractalwagmi/fractal-sdk-websdk-api';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { queryContext } from 'context/fractal-sdk-context';
 import { sdkApiClient, webSdkApiClient } from 'core/api/client';
 import { ApiFeature } from 'core/api/types';
 import {
@@ -80,6 +81,7 @@ export const useGetItemsQuery = () => {
     ItemApiKeys.getItems(user?.userId),
     async () => CoinApi.getItems(),
     {
+      context: queryContext,
       enabled: isNotNullOrUndefined(user),
     },
   );
@@ -97,6 +99,7 @@ export const useGetItemsForSaleQuery = (params: GetItemsForSaleParams) => {
     ItemApiKeys.getItemsForSale(params, user?.userId),
     async () => CoinApi.getItemsForSale(params),
     {
+      context: queryContext,
       // We require a user to be logged in to make this call because the API
       // requires an API access token.
       enabled: isNotNullOrUndefined(user),
@@ -130,6 +133,9 @@ export const useGenerateBuyTransactionMutation = () => {
         walletId,
       });
     },
+    {
+      context: queryContext,
+    },
   );
 };
 
@@ -155,6 +161,9 @@ export const useGenerateListTransactionMutation = () => {
         walletId,
       });
     },
+    {
+      context: queryContext,
+    },
   );
 };
 
@@ -177,6 +186,9 @@ export const useGenerateCancelListTransactionMutation = () => {
         tokenId,
         walletId,
       });
+    },
+    {
+      context: queryContext,
     },
   );
 };

--- a/src/queries/transaction.test.tsx
+++ b/src/queries/transaction.test.tsx
@@ -1,6 +1,7 @@
 import { FractalWebsdkTransactionGetTransactionStatusResponse } from '@fractalwagmi/fractal-sdk-websdk-api';
 import * as reactQuery from '@tanstack/react-query';
 import { renderHook, act } from '@testing-library/react-hooks/dom';
+import { queryContext } from 'context/fractal-sdk-context';
 import { webSdkApiClient } from 'core/api/client';
 import {
   FractalSDKTransactionStatusFetchInvalidError,
@@ -34,7 +35,7 @@ let wrapper: React.FC;
 beforeEach(() => {
   queryClient = new reactQuery.QueryClient();
   wrapper = ({ children }) => (
-    <reactQuery.QueryClientProvider client={queryClient}>
+    <reactQuery.QueryClientProvider client={queryClient} context={queryContext}>
       {children}
     </reactQuery.QueryClientProvider>
   );
@@ -152,7 +153,7 @@ describe('useGetTransactionStatusPoller', () => {
     );
   });
 
-  it('does not fetch when window is refocused', async () => {
+  fit('does not fetch when window is refocused', async () => {
     const { result, waitForValueToChange } = renderHook(
       () => useGetTransactionStatusPollerQuery(TEST_SIGNATURE),
       {

--- a/src/queries/transaction.test.tsx
+++ b/src/queries/transaction.test.tsx
@@ -153,7 +153,7 @@ describe('useGetTransactionStatusPoller', () => {
     );
   });
 
-  fit('does not fetch when window is refocused', async () => {
+  it('does not fetch when window is refocused', async () => {
     const { result, waitForValueToChange } = renderHook(
       () => useGetTransactionStatusPollerQuery(TEST_SIGNATURE),
       {

--- a/src/queries/transaction.ts
+++ b/src/queries/transaction.ts
@@ -1,5 +1,6 @@
 import { FractalWebsdkTransactionGetTransactionStatusResponse } from '@fractalwagmi/fractal-sdk-websdk-api';
 import { useQuery } from '@tanstack/react-query';
+import { queryContext } from 'context/fractal-sdk-context';
 import { webSdkApiClient } from 'core/api/client';
 import { ApiFeature } from 'core/api/types';
 import {
@@ -35,6 +36,7 @@ export const useGetTransactionStatusPollerQuery = (signature: string) => {
     TransactionApiKeys.getTransactionStatus(signature),
     async () => TransactionApi.getTransactionStatus(signature),
     {
+      context: queryContext,
       enabled: isNotNullOrUndefined(user),
       refetchInterval: shouldPoll ? secondsInMs(2) : false,
       refetchOnWindowFocus: false,


### PR DESCRIPTION
This ensures that any consuming apps that also use a `QueryClientProvider` won't accidentally overwrite the context, or the other way around where we overwrite the context unintentionally.

This makes it so that the SDK has its own context and cache, and the consuming app will have its own context (usually the default context) and cache.

Before this change, this SDK was also using the default context. The conflict was discovered as part of development for studio.fractal.is.